### PR TITLE
Improvements to the QR-code printout

### DIFF
--- a/manager/js/urls.js
+++ b/manager/js/urls.js
@@ -101,10 +101,10 @@ $.get(apiPrivate + '/units').fail(log).done(function (data) {
   let unitsToShow = [];
 
   data.configuredUnits.forEach(function (unit) {
-    if (unit.id.startsWith(prefix)) {
+    if (unit.id.startsWith(prefix) && unit.name.indexOf(name) !== -1) {
       unitsToShow.push(unit);
     } else {
-      console.info("Skipping unit with not-matching id.", unit);
+      console.info("Skipping unit because of filters 'prefix' or 'name'.", unit);
     }
   });
 

--- a/manager/js/urls.js
+++ b/manager/js/urls.js
@@ -85,7 +85,7 @@ let label = '';
 
 // prefix is required
 if (!prefix) {
-  alert('Prefix is required.');
+  $('#warning').text('Prefix is required.');
   throw 'Prefix is required.';
 }
 
@@ -107,6 +107,13 @@ $.get(apiPrivate + '/units').fail(log).done(function (data) {
       console.info("Skipping unit because of filters 'prefix' or 'name'.", unit);
     }
   });
+
+  if (0 === unitsToShow.length) {
+    $('#warning').text('No data to display, review the filters.');
+    throw 'No data.';
+  } else {
+    $('#info').text('Showing ' + unitsToShow.length + ' unit(s).');
+  }
 
   unitsToShow.sort(compareUnits);
 

--- a/manager/js/urls.js
+++ b/manager/js/urls.js
@@ -83,6 +83,12 @@ let label = '';
   }
 }
 
+// prefix is required
+if (!prefix) {
+  alert('Prefix is required.');
+  throw 'Prefix is required.';
+}
+
 function compareUnits(unitA, unitB) {
   if (unitA.name < unitB.name)
     return -1;

--- a/manager/js/urls.js
+++ b/manager/js/urls.js
@@ -65,10 +65,21 @@ function addUnitToView(unit) {
 }
 
 let prefix = '';
+let name = '';
+let label = '';
 {
   let params = (new URL(location)).searchParams;
   if (params.has('prefix')) {
     prefix = params.get('prefix');
+    $('#prefix').val(prefix);
+  }
+  if (params.has('name')) {
+    name = params.get('name');
+    $('#name').val(name);
+  }
+  if (params.has('label')) {
+    label = params.get('label');
+    $('#label').val(label);
   }
 }
 

--- a/manager/js/urls.js
+++ b/manager/js/urls.js
@@ -42,7 +42,7 @@ function addUnitToView(unit) {
   template.clone()
     .append(qr)
     .append($('<h1></h1>')
-      .text(unit.name)
+      .text(unit.name + (label ? ' - ' + label : ''))
     )
     .append($('<p></p>')
       .addClass('link-paragraph')

--- a/manager/urls.html
+++ b/manager/urls.html
@@ -51,11 +51,11 @@
   <p class="noprint">
     When printing, every unit's info comes on a separate page.
     (This header is not printed.).
-  <p>
-  <p class="noprint">Manage units <a href="index.html">here</a>.<p>
-  <p class="noprint">Manage incidents <a href="incidents.html">here</a>.<p>
-  <p class="noprint">Manage POIs <a href="pois.html">here</a>.<p>
-  <p class="noprint">Edit POIs in Coceso JSON format <a href="json.html">here</a>.<p>
+  </p>
+  <p class="noprint">Manage units <a href="index.html">here</a>.</p>
+  <p class="noprint">Manage incidents <a href="incidents.html">here</a>.</p>
+  <p class="noprint">Manage POIs <a href="pois.html">here</a>.</p>
+  <p class="noprint">Edit POIs in Coceso JSON format <a href="json.html">here</a>.</p>
 
   <script src="libs/jquery/jquery-3.3.1.min.js"></script>
   <script src="libs/qrcodejs/qrcode.js"></script>

--- a/manager/urls.html
+++ b/manager/urls.html
@@ -61,7 +61,11 @@
     <p>Unit prefix (concern id) - required: <input id="prefix" type="text" name="prefix"/></p>
     <p>Unit name contains - optional: <input id="name" type="text" name="name"/></p>
     <p>Label to print - optional: <input id="label" type="text" name="label"/></p>
-    <input type="submit" value="Reload"/>
+    <p>
+      <input type="submit" value="Reload"/>
+      <span id="warning" style="color: red"></span>
+      <span id="info"></span>
+    </p>
   </form><hr/></div>
 
   <script src="libs/jquery/jquery-3.3.1.min.js"></script>

--- a/manager/urls.html
+++ b/manager/urls.html
@@ -57,6 +57,13 @@
   <p class="noprint">Manage POIs <a href="pois.html">here</a>.</p>
   <p class="noprint">Edit POIs in Coceso JSON format <a href="json.html">here</a>.</p>
 
+  <div class="noprint"><hr/><form>
+    <p>Unit prefix (concern id) - required: <input id="prefix" type="text" name="prefix"/></p>
+    <p>Unit name contains - optional: <input id="name" type="text" name="name"/></p>
+    <p>Label to print - optional: <input id="label" type="text" name="label"/></p>
+    <input type="submit" value="Reload"/>
+  </form><hr/></div>
+
   <script src="libs/jquery/jquery-3.3.1.min.js"></script>
   <script src="libs/qrcodejs/qrcode.js"></script>
 


### PR DESCRIPTION
Providing command line parameters `prefix` (now required, #39), `name` (#40), and `label` (#38).
Providing a non-printing for to enter these parameters in a convenient way.